### PR TITLE
Avoid NullPointerException when getting applicable agreement 

### DIFF
--- a/src/main/java/uk/gov/homeoffice/digital/sas/balancecalculator/client/RestClient.java
+++ b/src/main/java/uk/gov/homeoffice/digital/sas/balancecalculator/client/RestClient.java
@@ -99,11 +99,15 @@ public class RestClient {
   public Agreement getApplicableAgreement(String tenantId, String personId, LocalDate accrualDate) {
 
     // Using Annual Target Hours accrual type, but any other accrual type would do
-    String agreementId = getAccrualByTypeAndDate(tenantId, personId,
-        AccrualType.ANNUAL_TARGET_HOURS.getId().toString(), accrualDate)
-        .getAgreementId().toString();
+    Accrual accrual = getAccrualByTypeAndDate(tenantId, personId,
+        AccrualType.ANNUAL_TARGET_HOURS.getId().toString(), accrualDate);
 
-    return getAgreementById(tenantId, agreementId);
+    if (accrual != null) {
+      String agreementId = accrual.getAgreementId().toString();
+
+      return getAgreementById(tenantId, agreementId);
+    }
+    return null;
   }
 
   public List<Accrual> patchAccruals(String tenantId, List<Accrual> accruals) {

--- a/src/test/java/uk/gov/homeoffice/digital/sas/balancecalculator/client/RestClientTest.java
+++ b/src/test/java/uk/gov/homeoffice/digital/sas/balancecalculator/client/RestClientTest.java
@@ -10,6 +10,7 @@ import static uk.gov.homeoffice.digital.sas.balancecalculator.testutils.CommonUt
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -33,6 +34,7 @@ import org.springframework.web.client.RestTemplate;
 import uk.gov.homeoffice.digital.sas.balancecalculator.models.ApiResponse;
 import uk.gov.homeoffice.digital.sas.balancecalculator.models.PatchBody;
 import uk.gov.homeoffice.digital.sas.balancecalculator.models.accrual.Accrual;
+import uk.gov.homeoffice.digital.sas.balancecalculator.models.accrual.Agreement;
 
 @ExtendWith(MockitoExtension.class)
 class RestClientTest {
@@ -41,6 +43,12 @@ class RestClientTest {
 
   @Captor
   ArgumentCaptor<HttpEntity<List<PatchBody>>> patchBodyListCaptor;
+
+  @Mock
+  ApiResponse<Accrual> emptyAccrualResponse;
+
+  @Mock
+  ApiResponse<Agreement> emptyAgreementResponse;
 
   @Mock
   RestTemplate restTemplate;
@@ -52,6 +60,48 @@ class RestClientTest {
     restClient = new RestClient();
     ReflectionTestUtils.setField(restClient, "restTemplate", restTemplate);
     ReflectionTestUtils.setField(restClient, "accrualsNoFilterUrl", "accruals/");
+    ReflectionTestUtils.setField(restClient, "accrualsFilterUrl", "accruals/");
+    ReflectionTestUtils.setField(restClient, "agreementsByIdUrl", "agreements/");
+  }
+
+  @Test
+  void getApplicableAgreement_accrualNotFound_shouldReturnNullAgreement() {
+
+    String tenantId = "3fa85f64-5717-4562-b3fc-2c963f66afa6";
+    String personId = "0936e7a6-2b2e-1696-2546-5dd25dcae6a0";
+    LocalDate accrualDate = LocalDate.of(2023,5,15);
+
+    when(restTemplate.exchange(any(String.class), eq(HttpMethod.GET),
+        Mockito.<HttpEntity<Accrual>>any() ,
+        Mockito.<ParameterizedTypeReference<ApiResponse<Accrual>>>any(),
+        Mockito.<Map<String, ?>>any()))
+        .thenReturn(new ResponseEntity<>(emptyAccrualResponse, HttpStatus.OK));
+
+    when(emptyAccrualResponse.getItems()).thenReturn(List.of());
+
+    Agreement applicableAgreement =
+        restClient.getApplicableAgreement(tenantId, personId, accrualDate);
+
+    assertThat(applicableAgreement).isNull();
+  }
+
+  @Test
+  void getAgreementById_agreementNotFound_shouldReturnNullAgreement() {
+
+    String tenantId = "3fa85f64-5717-4562-b3fc-2c963f66afa6";
+    String agreementId = "c0a80193-87a3-1ff0-8187-a3bfe2b80004";
+
+    when(restTemplate.exchange(any(String.class), eq(HttpMethod.GET),
+        Mockito.<HttpEntity<Agreement>>any() ,
+        Mockito.<ParameterizedTypeReference<ApiResponse<Agreement>>>any(),
+        Mockito.<Map<String, ?>>any()))
+        .thenReturn(new ResponseEntity<>(emptyAgreementResponse, HttpStatus.OK));
+
+    when(emptyAgreementResponse.getItems()).thenReturn(List.of());
+
+    Agreement agreement = restClient.getAgreementById(tenantId, agreementId);
+
+    assertThat(agreement).isNull();
   }
 
   @Test


### PR DESCRIPTION
Avoid NullPointerException when getting applicable agreement for a given date and no accrual record found