### PR TITLE
EAHW-1770: Refactor

### DIFF
--- a/src/test/java/uk/gov/homeoffice/digital/sas/balancecalculator/BalanceCalculatorCreateActionIntegrationTest.java
+++ b/src/test/java/uk/gov/homeoffice/digital/sas/balancecalculator/BalanceCalculatorCreateActionIntegrationTest.java
@@ -33,7 +33,7 @@ class BalanceCalculatorCreateActionIntegrationTest {
   }
 
   @Test
-  void calculate_endToEndInGmtToBst_contributionsAndCumulativeTotalsAsExpected() {
+  void calculate_annualTargetHoursGmtToBst_contributionsAndCumulativeTotalsAsExpected() {
 
     TimeEntry timeEntry = createTimeEntry(TIME_ENTRY_ID,
         TENANT_ID,
@@ -45,13 +45,25 @@ class BalanceCalculatorCreateActionIntegrationTest {
 
     assertThat(accruals).hasSize(8);
 
-    // Annual Target Hours
     assertTypeAndTotals(accruals.get(0), ANNUAL_TARGET_HOURS, 600, 6600);
     assertTypeAndTotals(accruals.get(1), ANNUAL_TARGET_HOURS, 600, 7200);
     assertTypeAndTotals(accruals.get(2), ANNUAL_TARGET_HOURS, 240, 7440);
     assertTypeAndTotals(accruals.get(3), ANNUAL_TARGET_HOURS, 720, 8160);
+  }
 
-    // Night Hours
+  @Test
+  void calculate_nightHoursGmtToBst_contributionsAndCumulativeTotalsAsExpected() {
+
+    TimeEntry timeEntry = createTimeEntry(TIME_ENTRY_ID,
+        TENANT_ID,
+        PERSON_ID,
+        "2023-03-26T00:59:00+00:00",
+        "2023-03-26T03:59:00+01:00");
+
+    List<Accrual> accruals = balanceCalculator.calculate(timeEntry, KafkaAction.CREATE);
+
+    assertThat(accruals).hasSize(8);
+
     assertTypeAndTotals(accruals.get(4), NIGHT_HOURS, 120, 1120);
     assertTypeAndTotals(accruals.get(5), NIGHT_HOURS, 120, 1240);
     assertTypeAndTotals(accruals.get(6), NIGHT_HOURS, 0, 1240);
@@ -59,7 +71,7 @@ class BalanceCalculatorCreateActionIntegrationTest {
   }
 
   @Test
-  void calculate_endToEndInBstToGmt_contributionsAndCumulativeTotalsAsExpected() {
+  void calculate_annualTargetHoursBstToGmt_contributionsAndCumulativeTotalsAsExpected() {
 
     TimeEntry timeEntry = createTimeEntry(TIME_ENTRY_ID,
         TENANT_ID,
@@ -71,13 +83,25 @@ class BalanceCalculatorCreateActionIntegrationTest {
 
     assertThat(accruals).hasSize(8);
 
-    // Annual Target Hours
     assertTypeAndTotals(accruals.get(0), ANNUAL_TARGET_HOURS, 600, 6600);
     assertTypeAndTotals(accruals.get(1), ANNUAL_TARGET_HOURS, 600, 7200);
     assertTypeAndTotals(accruals.get(2), ANNUAL_TARGET_HOURS, 240, 7440);
     assertTypeAndTotals(accruals.get(3), ANNUAL_TARGET_HOURS, 720, 8160);
+  }
 
-    // Night Hours
+  @Test
+  void calculate_nightHoursBstToGmt_contributionsAndCumulativeTotalsAsExpected() {
+
+    TimeEntry timeEntry = createTimeEntry(TIME_ENTRY_ID,
+        TENANT_ID,
+        PERSON_ID,
+        "2023-10-29T01:59:00+01:00",
+        "2023-10-29T02:59:00+00:00");
+
+    List<Accrual> accruals = balanceCalculator.calculate(timeEntry, KafkaAction.CREATE);
+
+    assertThat(accruals).hasSize(8);
+
     assertTypeAndTotals(accruals.get(4), NIGHT_HOURS, 120, 1120);
     assertTypeAndTotals(accruals.get(5), NIGHT_HOURS, 120, 1240);
     assertTypeAndTotals(accruals.get(6), NIGHT_HOURS, 0, 1240);
@@ -85,7 +109,7 @@ class BalanceCalculatorCreateActionIntegrationTest {
   }
 
   @Test
-  void calculate_timeEntryHasTwoDaysSpan_contributionsAndCumulativeTotalsAsExpected() {
+  void calculate_annualTargetHoursTimeEntryTwoDaysSpan_contributionsAndCumulativeTotalsAsExpected() {
 
     TimeEntry timeEntry = createTimeEntry(TIME_ENTRY_ID,
         TENANT_ID,
@@ -97,12 +121,24 @@ class BalanceCalculatorCreateActionIntegrationTest {
 
     assertThat(accruals).hasSize(6);
 
-    // Annual Target Hours
     assertTypeAndTotals(accruals.get(0), ANNUAL_TARGET_HOURS, 120, 8160);
     assertTypeAndTotals(accruals.get(1), ANNUAL_TARGET_HOURS, 420, 8580);
     assertTypeAndTotals(accruals.get(2), ANNUAL_TARGET_HOURS, 0, 8580);
+  }
 
-    // Night Hours
+  @Test
+  void calculate_nightHoursTimeEntryTwoDaysSpan_contributionsAndCumulativeTotalsAsExpected() {
+
+    TimeEntry timeEntry = createTimeEntry(TIME_ENTRY_ID,
+        TENANT_ID,
+        PERSON_ID,
+        "2023-04-22T22:00:00+01:00",
+        "2023-04-23T07:00:00+01:00");
+
+    List<Accrual> accruals = balanceCalculator.calculate(timeEntry, KafkaAction.CREATE);
+
+    assertThat(accruals).hasSize(6);
+
     assertTypeAndTotals(accruals.get(3), NIGHT_HOURS, 60, 1060);
     assertTypeAndTotals(accruals.get(4), NIGHT_HOURS, 360, 1420);
     assertTypeAndTotals(accruals.get(5), NIGHT_HOURS, 120, 1540);

--- a/src/test/java/uk/gov/homeoffice/digital/sas/balancecalculator/BalanceCalculatorCreateActionIntegrationTest.java
+++ b/src/test/java/uk/gov/homeoffice/digital/sas/balancecalculator/BalanceCalculatorCreateActionIntegrationTest.java
@@ -6,7 +6,6 @@ import static uk.gov.homeoffice.digital.sas.balancecalculator.models.accrual.enu
 import static uk.gov.homeoffice.digital.sas.balancecalculator.testutils.CommonUtils.createTimeEntry;
 
 import java.math.BigDecimal;
-import java.time.ZonedDateTime;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -36,14 +35,11 @@ class BalanceCalculatorCreateActionIntegrationTest {
   @Test
   void calculate_endToEndInGmtToBst_contributionsAndCumulativeTotalsAsExpected() {
 
-    ZonedDateTime startTime = ZonedDateTime.parse("2023-03-26T00:59:00+00:00");
-    ZonedDateTime finishTime = ZonedDateTime.parse("2023-03-26T03:59:00+01:00");
-
     TimeEntry timeEntry = createTimeEntry(TIME_ENTRY_ID,
         TENANT_ID,
         PERSON_ID,
-        startTime,
-        finishTime);
+        "2023-03-26T00:59:00+00:00",
+        "2023-03-26T03:59:00+01:00");
 
     List<Accrual> accruals = balanceCalculator.calculate(timeEntry, KafkaAction.CREATE);
 
@@ -65,14 +61,11 @@ class BalanceCalculatorCreateActionIntegrationTest {
   @Test
   void calculate_endToEndInBstToGmt_contributionsAndCumulativeTotalsAsExpected() {
 
-    ZonedDateTime startTime = ZonedDateTime.parse("2023-10-29T01:59:00+01:00");
-    ZonedDateTime finishTime = ZonedDateTime.parse("2023-10-29T02:59:00+00:00");
-
     TimeEntry timeEntry = createTimeEntry(TIME_ENTRY_ID,
         TENANT_ID,
         PERSON_ID,
-        startTime,
-        finishTime);
+        "2023-10-29T01:59:00+01:00",
+        "2023-10-29T02:59:00+00:00");
 
     List<Accrual> accruals = balanceCalculator.calculate(timeEntry, KafkaAction.CREATE);
 
@@ -94,14 +87,11 @@ class BalanceCalculatorCreateActionIntegrationTest {
   @Test
   void calculate_timeEntryHasTwoDaysSpan_contributionsAndCumulativeTotalsAsExpected() {
 
-    ZonedDateTime startTime = ZonedDateTime.parse("2023-04-22T22:00:00+01:00");
-    ZonedDateTime finishTime = ZonedDateTime.parse("2023-04-23T07:00:00+01:00");
-
     TimeEntry timeEntry = createTimeEntry(TIME_ENTRY_ID,
         TENANT_ID,
         PERSON_ID,
-        startTime,
-        finishTime);
+        "2023-04-22T22:00:00+01:00",
+        "2023-04-23T07:00:00+01:00");
 
     List<Accrual> accruals = balanceCalculator.calculate(timeEntry, KafkaAction.CREATE);
 

--- a/src/test/java/uk/gov/homeoffice/digital/sas/balancecalculator/BalanceCalculatorCreateActionTest.java
+++ b/src/test/java/uk/gov/homeoffice/digital/sas/balancecalculator/BalanceCalculatorCreateActionTest.java
@@ -50,12 +50,11 @@ import uk.gov.homeoffice.digital.sas.kafka.message.KafkaAction;
 @ExtendWith({MockitoExtension.class, OutputCaptureExtension.class})
 class BalanceCalculatorCreateActionTest {
 
-  private static final ZonedDateTime SHIFT_START_TIME =
-      ZonedDateTime.parse("2023-04-18T08:00:00+00:00");
-  private static final ZonedDateTime SHIFT_END_TIME =
-      ZonedDateTime.parse("2023-04-18T10:00:00+00:00");
+  private static final String SHIFT_START_TIME = "2023-04-18T08:00:00+00:00";
+  private static final String SHIFT_END_TIME = "2023-04-18T10:00:00+00:00";
 
-  private static final LocalDate ACCRUAL_DATE = SHIFT_START_TIME.toLocalDate();
+  private static final LocalDate ACCRUAL_DATE =
+      LocalDate.from(ZonedDateTime.parse(SHIFT_START_TIME));
   private static final String TIME_ENTRY_ID = "7f000001-879e-1b02-8187-9ef1640f0003";
   private static final String PERSON_ID = "0936e7a6-2b2e-1696-2546-5dd25dcae6a0";
   private static final LocalDate AGREEMENT_START_DATE = LocalDate.of(2023, 4, 1);
@@ -73,29 +72,29 @@ class BalanceCalculatorCreateActionTest {
         // creating one day time entry
         Arguments.of(TIME_ENTRY_ID,
             LocalDate.of(2023, 4, 18),
-            ZonedDateTime.parse("2023-04-18T08:00:00+00:00"),
-            ZonedDateTime.parse("2023-04-18T10:00:00+00:00"),
+            "2023-04-18T08:00:00+00:00",
+            "2023-04-18T10:00:00+00:00",
             BigDecimal.valueOf(6600), BigDecimal.valueOf(7200),
             BigDecimal.valueOf(7440), BigDecimal.valueOf(8160)),
         // updating one day time entry
         Arguments.of("e7d85e42-f0fb-4e2a-8211-874e27d1e888",
             LocalDate.of(2023, 4, 18),
-            ZonedDateTime.parse("2023-04-18T14:00:00+00:00"),
-            ZonedDateTime.parse("2023-04-18T14:30:00+00:00"),
+            "2023-04-18T14:00:00+00:00",
+            "2023-04-18T14:30:00+00:00",
             BigDecimal.valueOf(6150), BigDecimal.valueOf(6750),
             BigDecimal.valueOf(6990), BigDecimal.valueOf(7710)),
         // creating two day time entry
         Arguments.of("7f000001-879e-1b02-8187-9ef1640f0014",
             LocalDate.of(2023, 4, 19),
-            ZonedDateTime.parse("2023-04-18T22:00:00+00:00"),
-            ZonedDateTime.parse("2023-04-19T06:00:00+00:00"),
+            "2023-04-18T22:00:00+00:00",
+            "2023-04-19T06:00:00+00:00",
             BigDecimal.valueOf(6540), BigDecimal.valueOf(7560),
             BigDecimal.valueOf(7800), BigDecimal.valueOf(8520)),
         // creating three day time entry
         Arguments.of("7f000001-879e-1b02-8187-9ef1640f0013",
             LocalDate.of(2023, 4, 20),
-            ZonedDateTime.parse("2023-04-18T21:00:00+00:00"),
-            ZonedDateTime.parse("2023-04-20T06:00:00+00:00"),
+            "2023-04-18T21:00:00+00:00",
+            "2023-04-20T06:00:00+00:00",
             BigDecimal.valueOf(6600), BigDecimal.valueOf(8640),
             BigDecimal.valueOf(9300), BigDecimal.valueOf(10020))
     );
@@ -106,36 +105,36 @@ class BalanceCalculatorCreateActionTest {
         // outside night hours
         Arguments.of(TIME_ENTRY_ID,
             LocalDate.of(2023, 4, 18),
-            ZonedDateTime.parse("2023-04-18T08:00:00+01:00"),
-            ZonedDateTime.parse("2023-04-18T10:00:00+01:00"),
+            "2023-04-18T08:00:00+01:00",
+            "2023-04-18T10:00:00+01:00",
             BigDecimal.valueOf(6180), BigDecimal.valueOf(6300),
             BigDecimal.valueOf(6300), BigDecimal.valueOf(6300)),
         // creating one day time entry
         Arguments.of(TIME_ENTRY_ID,
             LocalDate.of(2023, 4, 18),
-            ZonedDateTime.parse("2023-04-18T00:00:00+01:00"),
-            ZonedDateTime.parse("2023-04-18T03:00:00+01:00"),
+            "2023-04-18T00:00:00+01:00",
+            "2023-04-18T03:00:00+01:00",
             BigDecimal.valueOf(6360), BigDecimal.valueOf(6480),
             BigDecimal.valueOf(6480), BigDecimal.valueOf(6480)),
         // updating one day time entry
         Arguments.of("e7d85e42-f0fb-4e2a-8211-874e27d1e888",
             LocalDate.of(2023, 4, 18),
-            ZonedDateTime.parse("2023-04-18T01:00:00+01:00"),
-            ZonedDateTime.parse("2023-04-18T05:00:00+01:00"),
+            "2023-04-18T01:00:00+01:00",
+            "2023-04-18T05:00:00+01:00",
             BigDecimal.valueOf(6240), BigDecimal.valueOf(6360),
             BigDecimal.valueOf(6360), BigDecimal.valueOf(6360)),
         // creating two day time entry
         Arguments.of(TIME_ENTRY_ID,
             LocalDate.of(2023, 4, 19),
-            ZonedDateTime.parse("2023-04-18T22:00:00+01:00"),
-            ZonedDateTime.parse("2023-04-19T06:00:00+01:00"),
+            "2023-04-18T22:00:00+01:00",
+            "2023-04-19T06:00:00+01:00",
             BigDecimal.valueOf(6240), BigDecimal.valueOf(6720),
             BigDecimal.valueOf(6720), BigDecimal.valueOf(6720)),
         // creating three day time entry
         Arguments.of(TIME_ENTRY_ID,
             LocalDate.of(2023, 4, 20),
-            ZonedDateTime.parse("2023-04-18T22:00:00+01:00"),
-            ZonedDateTime.parse("2023-04-20T07:00:00+01:00"),
+            "2023-04-18T22:00:00+01:00",
+            "2023-04-20T07:00:00+01:00",
             BigDecimal.valueOf(6240), BigDecimal.valueOf(6780),
             BigDecimal.valueOf(7140), BigDecimal.valueOf(7140))
     );
@@ -161,8 +160,8 @@ class BalanceCalculatorCreateActionTest {
   @MethodSource("annualTargetHoursTestData")
   void calculate_annualTargetHours_returnUpdateAccruals(String timeEntryId,
                                                         LocalDate referenceDate,
-                                                        ZonedDateTime shiftStartTime,
-                                                        ZonedDateTime shiftEndTime,
+                                                        String shiftStartTime,
+                                                        String shiftEndTime,
                                                         BigDecimal expectedCumulativeTotal1,
                                                         BigDecimal expectedCumulativeTotal2,
                                                         BigDecimal expectedCumulativeTotal3,
@@ -182,7 +181,7 @@ class BalanceCalculatorCreateActionTest {
         .thenReturn(loadObjectFromFile("data/agreement.json", Agreement.class));
 
     when(accrualsService.getImpactedAccruals(tenantId, PERSON_ID,
-        shiftStartTime.toLocalDate().minusDays(1),
+        ACCRUAL_DATE.minusDays(1),
         AGREEMENT_END_DATE))
         .thenReturn(loadAccrualsFromFile("data/accruals_annualTargetHours.json"));
 
@@ -200,8 +199,8 @@ class BalanceCalculatorCreateActionTest {
   @MethodSource("nightHoursTestData")
   void calculate_nightHours_returnUpdatedAccruals(String timeEntryId,
                                                   LocalDate referenceDate,
-                                                  ZonedDateTime shiftStartTime,
-                                                  ZonedDateTime shiftEndTime,
+                                                  String shiftStartTime,
+                                                  String shiftEndTime,
                                                   BigDecimal expectedCumulativeTotal1,
                                                   BigDecimal expectedCumulativeTotal2,
                                                   BigDecimal expectedCumulativeTotal3,
@@ -221,7 +220,7 @@ class BalanceCalculatorCreateActionTest {
         .thenReturn(loadObjectFromFile("data/agreement.json", Agreement.class));
 
     when(accrualsService.getImpactedAccruals(tenantId, PERSON_ID,
-        shiftStartTime.toLocalDate().minusDays(1),
+        ACCRUAL_DATE.minusDays(1),
         AGREEMENT_END_DATE))
         .thenReturn(loadAccrualsFromFile("data/accruals_nightHours.json"));
 

--- a/src/test/java/uk/gov/homeoffice/digital/sas/balancecalculator/BalanceCalculatorDeleteActionIntegrationTest.java
+++ b/src/test/java/uk/gov/homeoffice/digital/sas/balancecalculator/BalanceCalculatorDeleteActionIntegrationTest.java
@@ -6,7 +6,6 @@ import static uk.gov.homeoffice.digital.sas.balancecalculator.models.accrual.enu
 import static uk.gov.homeoffice.digital.sas.balancecalculator.testutils.CommonUtils.createTimeEntry;
 
 import java.math.BigDecimal;
-import java.time.ZonedDateTime;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -31,14 +30,11 @@ class BalanceCalculatorDeleteActionIntegrationTest {
   @Test
   void calculate_deleteAnnualTargetHoursOneDayTimeEntry_contributionsAndCumulativeTotalsAsExpected() {
 
-    ZonedDateTime startTime = ZonedDateTime.parse("2023-10-30T05:00:00+00:00");
-    ZonedDateTime finishTime = ZonedDateTime.parse("2023-10-30T07:00+00:00");
-
     TimeEntry timeEntry = createTimeEntry("85cd140e-9eeb-4771-ab6c-6dea17fcfcba",
         TENANT_ID,
         PERSON_ID,
-        startTime,
-        finishTime);
+        "2023-10-30T05:00:00+00:00",
+        "2023-10-30T07:00+00:00");
 
     List<Accrual> accruals = balanceCalculator.calculate(timeEntry, KafkaAction.DELETE);
 
@@ -53,14 +49,11 @@ class BalanceCalculatorDeleteActionIntegrationTest {
   @Test
   void calculate_deleteNightHoursOneDayTimeEntry_contributionsAndCumulativeTotalsAsExpected() {
 
-    ZonedDateTime startTime = ZonedDateTime.parse("2023-10-30T05:00:00+00:00");
-    ZonedDateTime finishTime = ZonedDateTime.parse("2023-10-30T07:00+00:00");
-
     TimeEntry timeEntry = createTimeEntry("85cd140e-9eeb-4771-ab6c-6dea17fcfcba",
         TENANT_ID,
         PERSON_ID,
-        startTime,
-        finishTime);
+        "2023-10-30T05:00:00+00:00",
+        "2023-10-30T07:00+00:00");
 
     List<Accrual> accruals = balanceCalculator.calculate(timeEntry, KafkaAction.DELETE);
 
@@ -75,14 +68,11 @@ class BalanceCalculatorDeleteActionIntegrationTest {
   @Test
   void calculate_deleteAnnualTargetHoursTwoDaysSpan_contributionsAndCumulativeTotalsAsExpected() {
 
-    ZonedDateTime startTime = ZonedDateTime.parse("2023-04-22T23:00:00+01:00");
-    ZonedDateTime finishTime = ZonedDateTime.parse("2023-04-23T07:00:00+01:00");
-
     TimeEntry timeEntry = createTimeEntry(TIME_ENTRY_ID,
         TENANT_ID,
         PERSON_ID,
-        startTime,
-        finishTime);
+        "2023-04-22T23:00:00+01:00",
+        "2023-04-23T07:00:00+01:00");
 
     List<Accrual> accruals = balanceCalculator.calculate(timeEntry, KafkaAction.DELETE);
 
@@ -96,14 +86,11 @@ class BalanceCalculatorDeleteActionIntegrationTest {
   @Test
   void calculate_deleteNightHoursTwoDaysSpan_contributionsAndCumulativeTotalsAsExpected() {
 
-    ZonedDateTime startTime = ZonedDateTime.parse("2023-04-22T23:00:00+01:00");
-    ZonedDateTime finishTime = ZonedDateTime.parse("2023-04-23T07:00:00+01:00");
-
     TimeEntry timeEntry = createTimeEntry(TIME_ENTRY_ID,
         TENANT_ID,
         PERSON_ID,
-        startTime,
-        finishTime);
+        "2023-04-22T23:00:00+01:00",
+        "2023-04-23T07:00:00+01:00");
 
     List<Accrual> accruals = balanceCalculator.calculate(timeEntry, KafkaAction.DELETE);
 

--- a/src/test/java/uk/gov/homeoffice/digital/sas/balancecalculator/BalanceCalculatorDeleteActionTest.java
+++ b/src/test/java/uk/gov/homeoffice/digital/sas/balancecalculator/BalanceCalculatorDeleteActionTest.java
@@ -45,22 +45,22 @@ class BalanceCalculatorDeleteActionTest {
         // deleting one day time entry
         Arguments.of("38e09687-5ae7-40d6-82b4-b022ae456bb1",
             LocalDate.of(2023, 4, 18),
-            ZonedDateTime.parse("2023-04-18T08:00:00+00:00"),
-            ZonedDateTime.parse("2023-04-18T10:00:00+00:00"),
+            "2023-04-18T08:00:00+00:00",
+            "2023-04-18T10:00:00+00:00",
             BigDecimal.valueOf(6720), BigDecimal.valueOf(7320),
             BigDecimal.valueOf(7920), BigDecimal.valueOf(8640)),
         // deleting two day time entry
         Arguments.of("e7d85e42-f0fb-4e2a-8211-874e27d1e888",
             LocalDate.of(2023, 4, 19),
-            ZonedDateTime.parse("2023-04-18T18:00:00+00:00"),
-            ZonedDateTime.parse("2023-04-19T06:00:00+00:00"),
+            "2023-04-18T18:00:00+00:00",
+            "2023-04-19T06:00:00+00:00",
             BigDecimal.valueOf(6480), BigDecimal.valueOf(6720),
             BigDecimal.valueOf(7320), BigDecimal.valueOf(8040)),
         // deleting three day time entry
         Arguments.of("51a0a8eb-5972-406b-a539-4f4793ec3cb9",
             LocalDate.of(2023, 4, 20),
-            ZonedDateTime.parse("2023-04-18T18:00:00+00:00"),
-            ZonedDateTime.parse("2023-04-20T06:00:00+00:00"),
+            "2023-04-18T18:00:00+00:00",
+            "2023-04-20T06:00:00+00:00",
             BigDecimal.valueOf(6480), BigDecimal.valueOf(6960),
             BigDecimal.valueOf(7200), BigDecimal.valueOf(7920))
     );
@@ -71,22 +71,22 @@ class BalanceCalculatorDeleteActionTest {
         // deleting one day time entry
         Arguments.of("aed8cfb5-c82a-4fdf-9534-2170d0af14f8",
             LocalDate.of(2023, 4, 18),
-            ZonedDateTime.parse("2023-04-18T00:00:00+01:00"),
-            ZonedDateTime.parse("2023-04-18T06:00:00+01:00"),
+            "2023-04-18T00:00:00+01:00",
+            "2023-04-18T06:00:00+01:00",
             BigDecimal.valueOf(6120), BigDecimal.valueOf(6660),
             BigDecimal.valueOf(7020), BigDecimal.valueOf(7020)),
         // deleting two day time entry
         Arguments.of("e7d85e42-f0fb-4e2a-8211-874e27d1e888",
             LocalDate.of(2023, 4, 19),
-            ZonedDateTime.parse("2023-04-18T22:00:00+01:00"),
-            ZonedDateTime.parse("2023-04-19T02:00:00+01:00"),
+            "2023-04-18T22:00:00+01:00",
+            "2023-04-19T02:00:00+01:00",
             BigDecimal.valueOf(6420), BigDecimal.valueOf(6840),
             BigDecimal.valueOf(7200), BigDecimal.valueOf(7200)),
         // deleting three day time entry
         Arguments.of("7ea794b4-d87f-42c9-a534-187291c168ac",
             LocalDate.of(2023, 4, 20),
-            ZonedDateTime.parse("2023-04-18T22:00:00+01:00"),
-            ZonedDateTime.parse("2023-04-20T07:00:00+01:00"),
+            "2023-04-18T22:00:00+01:00",
+            "2023-04-20T07:00:00+01:00",
             BigDecimal.valueOf(6420), BigDecimal.valueOf(6540),
             BigDecimal.valueOf(6540), BigDecimal.valueOf(6540))
     );
@@ -96,8 +96,8 @@ class BalanceCalculatorDeleteActionTest {
   @MethodSource("annualTargetHoursTestData")
   void calculate_annualTargetHours_returnUpdateAccruals(String timeEntryId,
                                                         LocalDate referenceDate,
-                                                        ZonedDateTime shiftStartTime,
-                                                        ZonedDateTime shiftEndTime,
+                                                        String shiftStartTime,
+                                                        String shiftEndTime,
                                                         BigDecimal expectedCumulativeTotal1,
                                                         BigDecimal expectedCumulativeTotal2,
                                                         BigDecimal expectedCumulativeTotal3,
@@ -117,7 +117,7 @@ class BalanceCalculatorDeleteActionTest {
         .thenReturn(loadObjectFromFile("data/agreement.json", Agreement.class));
 
     when(accrualsService.getImpactedAccruals(tenantId, PERSON_ID,
-        shiftStartTime.toLocalDate().minusDays(1),
+        LocalDate.from(ZonedDateTime.parse(shiftStartTime).minusDays(1)),
         AGREEMENT_END_DATE))
         .thenReturn(loadAccrualsFromFile("data/accruals_annualTargetHoursDeleteAction.json"));
 
@@ -135,8 +135,8 @@ class BalanceCalculatorDeleteActionTest {
   @MethodSource("nightHoursTestData")
   void calculate_nightHours_returnUpdatedAccruals(String timeEntryId,
                                                   LocalDate referenceDate,
-                                                  ZonedDateTime shiftStartTime,
-                                                  ZonedDateTime shiftEndTime,
+                                                  String shiftStartTime,
+                                                  String shiftEndTime,
                                                   BigDecimal expectedCumulativeTotal1,
                                                   BigDecimal expectedCumulativeTotal2,
                                                   BigDecimal expectedCumulativeTotal3,
@@ -156,7 +156,7 @@ class BalanceCalculatorDeleteActionTest {
         .thenReturn(loadObjectFromFile("data/agreement.json", Agreement.class));
 
     when(accrualsService.getImpactedAccruals(tenantId, PERSON_ID,
-        shiftStartTime.toLocalDate().minusDays(1),
+        LocalDate.from(ZonedDateTime.parse(shiftStartTime).minusDays(1)),
         AGREEMENT_END_DATE))
         .thenReturn(loadAccrualsFromFile("data/accruals_nightHoursDeleteAction.json"));
 

--- a/src/test/java/uk/gov/homeoffice/digital/sas/balancecalculator/kafka/consumer/KafkaConsumerIntegrationTest.java
+++ b/src/test/java/uk/gov/homeoffice/digital/sas/balancecalculator/kafka/consumer/KafkaConsumerIntegrationTest.java
@@ -73,8 +73,8 @@ class KafkaConsumerIntegrationTest {
     // Given
 
     TimeEntry timeEntry = CommonUtils.createTimeEntry(TIME_ENTRY_ID, OWNER_ID,
-        SHIFT_START_TIME,
-        SHIFT_END_TIME);
+        SHIFT_START_TIME.toString(),
+        SHIFT_END_TIME.toString());
     kafkaEventMessage = new KafkaEventMessage<>(MESSAGE_VALID_VERSION, timeEntry,
         KafkaAction.CREATE);
 
@@ -96,8 +96,8 @@ class KafkaConsumerIntegrationTest {
   void should_throwException_when_versionInvalid() throws JsonProcessingException {
     // Given
     TimeEntry timeEntry = CommonUtils.createTimeEntry(TIME_ENTRY_ID, OWNER_ID,
-        SHIFT_START_TIME,
-        SHIFT_END_TIME);
+        SHIFT_START_TIME.toString(),
+        SHIFT_END_TIME.toString());
 
     String message = createKafkaMessage(VALID_RESOURCE_SCHEMA, MESSAGE_INVALID_VERSION
         , TIME_ENTRY_ID, OWNER_ID);
@@ -121,8 +121,8 @@ class KafkaConsumerIntegrationTest {
   void should_throwException_when_resourceInvalid() throws JsonProcessingException {
     // Given
     TimeEntry timeEntry = CommonUtils.createTimeEntry(TIME_ENTRY_ID, OWNER_ID,
-        SHIFT_START_TIME,
-        SHIFT_END_TIME);
+        SHIFT_START_TIME.toString(),
+        SHIFT_END_TIME.toString());
 
     String message = createKafkaMessage(INVALID_RESOURCE_SCHEMA, MESSAGE_VALID_VERSION
         , TIME_ENTRY_ID, OWNER_ID);

--- a/src/test/java/uk/gov/homeoffice/digital/sas/balancecalculator/module/AnnualTargetHoursAccrualModuleTest.java
+++ b/src/test/java/uk/gov/homeoffice/digital/sas/balancecalculator/module/AnnualTargetHoursAccrualModuleTest.java
@@ -5,7 +5,6 @@ import static uk.gov.homeoffice.digital.sas.balancecalculator.testutils.CommonUt
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
-import java.time.ZonedDateTime;
 import java.util.SortedMap;
 import java.util.TreeMap;
 import java.util.stream.Stream;
@@ -21,31 +20,31 @@ class AnnualTargetHoursAccrualModuleTest {
   private static Stream<Arguments> testData() {
     return Stream.of(
         // Daylight saving switch
-        Arguments.of(createTimeEntry(ZonedDateTime.parse("2023-03-26T00:00:00+00:00"),
-                ZonedDateTime.parse("2023-03-26T05:00:00+01:00")),
+        Arguments.of(createTimeEntry("2023-03-26T00:00:00+00:00",
+                "2023-03-26T05:00:00+01:00"),
             new TreeMap<LocalDate, BigDecimal>() {{
               this.put(LocalDate.parse("2023-03-26"), BigDecimal.valueOf(240));
             }}),
-        Arguments.of(createTimeEntry(ZonedDateTime.parse("2023-04-18T08:00:00+01:00"),
-                ZonedDateTime.parse("2023-04-18T10:00:00+01:00")),
+        Arguments.of(createTimeEntry("2023-04-18T08:00:00+01:00",
+                "2023-04-18T10:00:00+01:00"),
             new TreeMap<LocalDate, BigDecimal>() {{
               this.put(LocalDate.parse("2023-04-18"), BigDecimal.valueOf(120));
             }}),
-        Arguments.of(createTimeEntry(ZonedDateTime.parse("2023-10-29T00:00:00+01:00"),
-                ZonedDateTime.parse("2023-10-29T02:00:00+00:00")),
+        Arguments.of(createTimeEntry("2023-10-29T00:00:00+01:00",
+                "2023-10-29T02:00:00+00:00"),
             new TreeMap<LocalDate, BigDecimal>() {{
               this.put(LocalDate.parse("2023-10-29"), BigDecimal.valueOf(180));
             }}),
         // two day time entry
-        Arguments.of(createTimeEntry(ZonedDateTime.parse("2023-11-01T20:00:00+00:00"),
-                ZonedDateTime.parse("2023-11-02T10:00:00+00:00")),
+        Arguments.of(createTimeEntry("2023-11-01T20:00:00+00:00",
+                "2023-11-02T10:00:00+00:00"),
             new TreeMap<LocalDate, BigDecimal>() {{
               this.put(LocalDate.parse("2023-11-01"), BigDecimal.valueOf(240));
               this.put(LocalDate.parse("2023-11-02"), BigDecimal.valueOf(600));
             }}),
         // three day time entry
-        Arguments.of(createTimeEntry(ZonedDateTime.parse("2023-11-01T20:00:00+00:00"),
-                ZonedDateTime.parse("2023-11-03T10:00:00+00:00")),
+        Arguments.of(createTimeEntry("2023-11-01T20:00:00+00:00",
+                "2023-11-03T10:00:00+00:00"),
             new TreeMap<LocalDate, BigDecimal>() {{
               this.put(LocalDate.parse("2023-11-01"), BigDecimal.valueOf(240));
               this.put(LocalDate.parse("2023-11-02"), BigDecimal.valueOf(1440));

--- a/src/test/java/uk/gov/homeoffice/digital/sas/balancecalculator/module/NightHoursAccrualModuleTest.java
+++ b/src/test/java/uk/gov/homeoffice/digital/sas/balancecalculator/module/NightHoursAccrualModuleTest.java
@@ -5,7 +5,6 @@ import static uk.gov.homeoffice.digital.sas.balancecalculator.testutils.CommonUt
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
-import java.time.ZonedDateTime;
 import java.util.SortedMap;
 import java.util.TreeMap;
 import java.util.stream.Stream;
@@ -21,72 +20,72 @@ class NightHoursAccrualModuleTest {
   private static Stream<Arguments> testData() {
     return Stream.of(
         // Outside night hours
-        Arguments.of(createTimeEntry(ZonedDateTime.parse("2023-04-18T08:00:00+01:00"),
-                ZonedDateTime.parse("2023-04-18T10:00:00+01:00")),
+        Arguments.of(createTimeEntry("2023-04-18T08:00:00+01:00",
+                "2023-04-18T10:00:00+01:00"),
             new TreeMap<LocalDate, BigDecimal>() {{
               this.put(LocalDate.parse("2023-04-18"), BigDecimal.valueOf(0));
             }}
         ),
-        Arguments.of(createTimeEntry(ZonedDateTime.parse("2023-03-18T00:00:00+00:00"),
-                ZonedDateTime.parse("2023-03-18T06:00:00+00:00")),
+        Arguments.of(createTimeEntry("2023-03-18T00:00:00+00:00",
+                "2023-03-18T06:00:00+00:00"),
             new TreeMap<LocalDate, BigDecimal>() {{
               this.put(LocalDate.parse("2023-03-18"), BigDecimal.valueOf(360));
             }}
         ),
-        Arguments.of(createTimeEntry(ZonedDateTime.parse("2023-03-18T04:00:00+00:00"),
-                ZonedDateTime.parse("2023-03-18T10:00:00+00:00")),
+        Arguments.of(createTimeEntry("2023-03-18T04:00:00+00:00",
+                "2023-03-18T10:00:00+00:00"),
             new TreeMap<LocalDate, BigDecimal>() {{
               this.put(LocalDate.parse("2023-03-18"), BigDecimal.valueOf(120));
             }}
         ),
-        Arguments.of(createTimeEntry(ZonedDateTime.parse("2023-03-18T14:00:00+00:00"),
-                ZonedDateTime.parse("2023-03-18T23:30:00+00:00")),
+        Arguments.of(createTimeEntry("2023-03-18T14:00:00+00:00",
+                "2023-03-18T23:30:00+00:00"),
             new TreeMap<LocalDate, BigDecimal>() {{
               this.put(LocalDate.parse("2023-03-18"), BigDecimal.valueOf(30));
             }}
         ),
-        Arguments.of(createTimeEntry(ZonedDateTime.parse("2023-03-18T23:30:00+00:00"),
-                ZonedDateTime.parse("2023-03-18T23:59:00+00:00")),
+        Arguments.of(createTimeEntry("2023-03-18T23:30:00+00:00",
+                "2023-03-18T23:59:00+00:00"),
             new TreeMap<LocalDate, BigDecimal>() {{
               this.put(LocalDate.parse("2023-03-18"), BigDecimal.valueOf(29));
             }}
         ),
-        Arguments.of(createTimeEntry(ZonedDateTime.parse("2023-03-18T22:30:00+00:00"),
-                ZonedDateTime.parse("2023-03-19T00:00:00+00:00")),
+        Arguments.of(createTimeEntry("2023-03-18T22:30:00+00:00",
+                "2023-03-19T00:00:00+00:00"),
             new TreeMap<LocalDate, BigDecimal>() {{
               this.put(LocalDate.parse("2023-03-18"), BigDecimal.valueOf(60));
             }}
         ),
-        Arguments.of(createTimeEntry(ZonedDateTime.parse("2023-03-18T00:00:00+00:00"),
-                ZonedDateTime.parse("2023-03-19T00:00:00+00:00")),
+        Arguments.of(createTimeEntry("2023-03-18T00:00:00+00:00",
+                "2023-03-19T00:00:00+00:00"),
             new TreeMap<LocalDate, BigDecimal>() {{
               this.put(LocalDate.parse("2023-03-18"), BigDecimal.valueOf(420));
             }}
         ),
         // GMT to BST
-        Arguments.of(createTimeEntry(ZonedDateTime.parse("2023-03-26T00:00:00+00:00"),
-                ZonedDateTime.parse("2023-03-26T05:00:00+01:00")),
+        Arguments.of(createTimeEntry("2023-03-26T00:00:00+00:00",
+                "2023-03-26T05:00:00+01:00"),
             new TreeMap<LocalDate, BigDecimal>() {{
               this.put(LocalDate.parse("2023-03-26"), BigDecimal.valueOf(240));
             }}
         ),
         // BST to GMT
-        Arguments.of(createTimeEntry(ZonedDateTime.parse("2023-10-29T00:00:00+01:00"),
-                ZonedDateTime.parse("2023-10-29T02:00:00+00:00")),
+        Arguments.of(createTimeEntry("2023-10-29T00:00:00+01:00",
+                "2023-10-29T02:00:00+00:00"),
             new TreeMap<LocalDate, BigDecimal>() {{
               this.put(LocalDate.parse("2023-10-29"), BigDecimal.valueOf(180));
             }}
         ),
         // two day time entry
-        Arguments.of(createTimeEntry(ZonedDateTime.parse("2023-11-01T20:00:00+00:00"),
-                ZonedDateTime.parse("2023-11-02T10:00:00+00:00")),
+        Arguments.of(createTimeEntry("2023-11-01T20:00:00+00:00",
+                "2023-11-02T10:00:00+00:00"),
             new TreeMap<LocalDate, BigDecimal>() {{
               this.put(LocalDate.parse("2023-11-01"), BigDecimal.valueOf(60));
               this.put(LocalDate.parse("2023-11-02"), BigDecimal.valueOf(360));
             }}),
         // three day time entry
-        Arguments.of(createTimeEntry(ZonedDateTime.parse("2023-11-01T20:00:00+00:00"),
-                ZonedDateTime.parse("2023-11-03T10:00:00+00:00")),
+        Arguments.of(createTimeEntry("2023-11-01T20:00:00+00:00",
+                "2023-11-03T10:00:00+00:00"),
             new TreeMap<LocalDate, BigDecimal>() {{
               this.put(LocalDate.parse("2023-11-01"), BigDecimal.valueOf(60));
               this.put(LocalDate.parse("2023-11-02"), BigDecimal.valueOf(420));

--- a/src/test/java/uk/gov/homeoffice/digital/sas/balancecalculator/testutils/CommonUtils.java
+++ b/src/test/java/uk/gov/homeoffice/digital/sas/balancecalculator/testutils/CommonUtils.java
@@ -26,19 +26,19 @@ public class CommonUtils {
 
   private static final ObjectMapper mapper = new ObjectMapper();
 
-  public static TimeEntry createTimeEntry(ZonedDateTime startTime,
-                                          ZonedDateTime finishTime) {
+  public static TimeEntry createTimeEntry(String startTime,
+                                          String finishTime) {
     return createTimeEntry(VALID_TIME_ENTRY_ID, VALID_TENANT_ID, VALID_PERSON_ID,
         startTime, finishTime);
   }
 
-  public static TimeEntry createTimeEntry(String id, String ownerId, ZonedDateTime startTime,
-                                          ZonedDateTime finishTime) {
+  public static TimeEntry createTimeEntry(String id, String ownerId, String startTime,
+                                          String finishTime) {
     return createTimeEntry(id, VALID_TENANT_ID, ownerId, startTime, finishTime);
   }
 
   public static TimeEntry createTimeEntry(String id, String tenantId, String ownerId,
-                                          ZonedDateTime startTime, ZonedDateTime finishTime) {
+                                          String startTime, String finishTime) {
 
     var timeEntry = new TimeEntry();
     timeEntry.setId(id);
@@ -46,8 +46,8 @@ public class CommonUtils {
     timeEntry.setOwnerId(ownerId);
     timeEntry.setTimePeriodTypeId(VALID_TIME_PERIOD_TYPE_ID);
     timeEntry.setShiftType(EMPTY_STRING);
-    timeEntry.setActualStartTime(startTime);
-    timeEntry.setActualEndTime(finishTime);
+    timeEntry.setActualStartTime(ZonedDateTime.parse(startTime));
+    timeEntry.setActualEndTime(ZonedDateTime.parse(finishTime));
     return timeEntry;
   }
 


### PR DESCRIPTION
- Refactored `createTimeEntry` function to take a string instead of ZonedDateTime to reduce repetition of `ZonedDateTime.parse()`
- Separated assert statements for annual target hours and night hours in create integration tests to mirror delete tests