### PR TITLE
Handle case when there is no prior accrual record

### DIFF
--- a/src/main/java/uk/gov/homeoffice/digital/sas/balancecalculator/BalanceCalculator.java
+++ b/src/main/java/uk/gov/homeoffice/digital/sas/balancecalculator/BalanceCalculator.java
@@ -63,15 +63,15 @@ public class BalanceCalculator {
       return List.of();
     }
 
-    // Get accruals of all types between the day just before the time entry and the end date of the
+    // Get accruals of all types between the day prior to the time entry and the end date of the
     // latest applicable agreement
+    LocalDate priorDate = timeEntryStartDate.minusDays(1);
     SortedMap<AccrualType, SortedMap<LocalDate, Accrual>> allAccruals =
-        getImpactedAccruals(tenantId, personId,
-            timeEntryStartDate.minusDays(1), applicableAgreement.getEndDate());
+        getImpactedAccruals(tenantId, personId, priorDate, applicableAgreement.getEndDate());
 
     if (isEmpty(allAccruals)) {
       log.warn(MessageFormat.format(ACCRUALS_NOT_FOUND, tenantId, personId,
-          timeEntryStartDate.minusDays(1), applicableAgreement.getEndDate()));
+          priorDate, applicableAgreement.getEndDate()));
       return List.of();
     }
 
@@ -86,7 +86,7 @@ public class BalanceCalculator {
     // Each AccrualType within allAccruals map still containing entry for prior day
     // which shouldn't be sent to batch update. Lines below removing that entry from the Map
     for (SortedMap<LocalDate, Accrual> value : allAccruals.values()) {
-      value.remove(value.firstKey());
+      value.remove(priorDate);
     }
 
     return allAccruals.values().stream()

--- a/src/test/java/uk/gov/homeoffice/digital/sas/balancecalculator/handlers/ContributionsHandlerTest.java
+++ b/src/test/java/uk/gov/homeoffice/digital/sas/balancecalculator/handlers/ContributionsHandlerTest.java
@@ -100,10 +100,11 @@ class ContributionsHandlerTest {
 
     LocalDate agreementStartDate = LocalDate.of(2023, 4, 1);
     LocalDate referenceDate = LocalDate.of(2023, 4, 18);
+    LocalDate priorDate = referenceDate.minusDays(1);
 
-    contributionsHandler.cascadeCumulativeTotal(map, agreementStartDate);
+    contributionsHandler.cascadeCumulativeTotal(map, priorDate, agreementStartDate);
 
-    assertThat(map).hasSize(5);
+    assertThat(map).hasSize(4);
     assertThat(map.get(referenceDate)
         .getCumulativeTotal()).usingComparator(BigDecimal::compareTo)
         .isEqualTo(BigDecimal.valueOf(6480));
@@ -125,10 +126,11 @@ class ContributionsHandlerTest {
   void cascadeCumulativeTotal_emptyMapOfAccruals_throwException() {
     SortedMap<LocalDate, Accrual> map = new TreeMap<>();
 
+    LocalDate timeEntryStartDate = LocalDate.of(2023, 4, 15);
     LocalDate agreementStartDate = LocalDate.of(2023, 4, 1);
 
     assertThatThrownBy(() ->
-        contributionsHandler.cascadeCumulativeTotal(map, agreementStartDate))
+        contributionsHandler.cascadeCumulativeTotal(map, timeEntryStartDate, agreementStartDate))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining(ACCRUALS_MAP_EMPTY);
   }

--- a/src/test/resources/data/accruals_noPriorDateAccrual.json
+++ b/src/test/resources/data/accruals_noPriorDateAccrual.json
@@ -1,0 +1,70 @@
+[
+  {
+    "id": "c0a80193-87a3-1ff0-8187-a4277b0b0008",
+    "tenantId": "52a8188b-d41e-6768-19e9-09938016342f",
+    "personId": "0936e7a6-2b2e-1696-2546-5dd25dcae6a0",
+    "agreementId": "c0a80193-87a3-1ff0-8187-a3bfe2b80004",
+    "accrualDate": "2023-04-01",
+    "accrualTypeId": "e502eebb-4663-4e5b-9445-9a20441c18d9",
+    "cumulativeTotal": 6480,
+    "cumulativeTarget": 9120,
+    "contributions": {
+      "timeEntries": {
+        "85cd140e-9eeb-4771-ab6c-6dea17fcfcba": 120.00,
+        "e7d85e42-f0fb-4e2a-8211-874e27d1e888": 360.00
+      },
+      "total": 480.00
+    }
+  },
+  {
+    "id": "c0a80193-87a3-1ff0-8187-a4277b0b0008",
+    "tenantId": "52a8188b-d41e-6768-19e9-09938016342f",
+    "personId": "0936e7a6-2b2e-1696-2546-5dd25dcae6a0",
+    "agreementId": "c0a80193-87a3-1ff0-8187-a3bfe2b80004",
+    "accrualDate": "2023-04-02",
+    "accrualTypeId": "e502eebb-4663-4e5b-9445-9a20441c18d9",
+    "cumulativeTotal": 7080,
+    "cumulativeTarget": 9600,
+    "contributions": {
+      "timeEntries": {
+        "7f000001-879e-1b02-8187-9ef1640f00a3": 120.00,
+        "85cd140e-9eeb-4771-ab6c-6dea17fcfcba": 120.00,
+        "e7d85e42-f0fb-4e2a-8211-874e27d1e888": 360.00
+      },
+      "total": 600.00
+    }
+  },
+  {
+    "id": "c0a80193-87a3-1ff0-8187-a4277b0b0008",
+    "tenantId": "52a8188b-d41e-6768-19e9-09938016342f",
+    "personId": "0936e7a6-2b2e-1696-2546-5dd25dcae6a0",
+    "agreementId": "c0a80193-87a3-1ff0-8187-a3bfe2b80004",
+    "accrualDate": "2023-04-03",
+    "accrualTypeId": "e502eebb-4663-4e5b-9445-9a20441c18d9",
+    "cumulativeTotal": 7320,
+    "cumulativeTarget": 10080,
+    "contributions": {
+      "timeEntries": {
+        "9caab6a7-31a5-4679-bd14-fbf09b1cec92": 240.00
+      },
+      "total": 240.00
+    }
+  },
+  {
+    "id": "c0a80193-87a3-1ff0-8187-a4277b0b0008",
+    "tenantId": "52a8188b-d41e-6768-19e9-09938016342f",
+    "personId": "0936e7a6-2b2e-1696-2546-5dd25dcae6a0",
+    "agreementId": "c0a80193-87a3-1ff0-8187-a3bfe2b80004",
+    "accrualDate": "2023-04-04",
+    "accrualTypeId": "e502eebb-4663-4e5b-9445-9a20441c18d9",
+    "cumulativeTotal": 8040,
+    "cumulativeTarget": 10560,
+    "contributions": {
+      "timeEntries": {
+        "5afbfbeb-0d65-4e7e-bced-fb7e3a214c76": 480.00,
+        "fee2523d-380e-4116-b2f3-d526d1b6ab55": 240.00
+      },
+      "total": 720.00
+    }
+  }
+]


### PR DESCRIPTION
 Handle case when there is no accrual record for date prior to time entry start date

To exclude prior date accrual from update, remove by key=priorDate, instead of blindly removing the first element